### PR TITLE
Fix config for explicitly broken menu items and remove misplaced items

### DIFF
--- a/src/share/genmenu/db.csv
+++ b/src/share/genmenu/db.csv
@@ -22,7 +22,7 @@ app-forensics/cmospwd,forensics,cmospwd
 app-forensics/dff,forensics,dff.desktop
 app-forensics/foremost,forensics,foremost
 app-forensics/galleta,forensics,galleta
-app-forensics/inception,forensics,inception
+app-forensics/inception,forensics,inception.desktop
 app-forensics/libvshadow,forensics,vshadowinfo vshadowmount
 app-forensics/make-pdf,exploit amke-pdf,make-pdf-javascript make-pdf-embedded
 app-forensics/memdump,forensics,memdump
@@ -66,7 +66,7 @@ dev-db/sqlmap,database,sqlmap
 dev-java/jad-bin,rce,jad
 dev-lang/nasm,rce,nasm
 dev-util/apktool,mobile,apktool
-dev-util/dex2jar,mobile,dex2jar
+dev-util/dex2jar,mobile,dex2jar.desktop
 dev-util/edb,rce,edb.desktop
 dev-util/emilpro,rce,emilpro
 dev-util/insight,rce,insight
@@ -148,7 +148,7 @@ net-analyzer/rain,forging,rain,--help
 net-analyzer/scanssh,footprint Fingerprint Services,scanssh
 net-analyzer/set,exploit SET,setoolkit set-web set-automate set-proxy
 net-analyzer/siphon,footprint Fingerprint OS,siphon
-net-analyzer/sipvicious,sip-voip Sipvicious,svmap svreport svwar svcrack
+net-analyzer/sipvicious,sip-voip Sipvicious,svmap.desktop svreport.desktop svwar.desktop svcrack.desktop
 net-analyzer/smtpmap,footprint Fingerprint Services,smtpmap
 net-analyzer/sniffit,analyzer,sniffit
 net-analyzer/snmpenum,analyzer,snmpenum

--- a/src/share/genmenu/db.csv
+++ b/src/share/genmenu/db.csv
@@ -192,7 +192,6 @@ net-fs/winexe,exploit,winexe
 net-ftp/ftpd,misc,ftpd.desktop
 net-ftp/oftpd,misc,oftpd
 net-irc/irssi,none,irssi,--help
-net-libs/libbtbb,bluetooth,libbtbb
 net-misc/bridge-utils,mitm,brctl
 net-misc/curl,misc,curl
 net-misc/dhcpcd,misc,dhcpcd
@@ -279,7 +278,6 @@ net-wireless/wifite,wireless,wifite
 net-www/apache,misc,apache.desktop
 sci-geosciences/gpsd,wireless,gpsd
 sys-apps/dcfldd,forensics,dcfldd,--help
-sys-devel/clang,mobile,clang,--help
 sys-devel/gdb,rce,gdb
 sys-fs/dd-rescue,forensics,dd_rescue
 sys-fs/ddrescue,forensics,ddrescue

--- a/src/share/genmenu/desktop/dex2jar.desktop
+++ b/src/share/genmenu/desktop/dex2jar.desktop
@@ -3,3 +3,4 @@ Name=Dex2jar
 Exec=/bin/sh -c "/usr/bin/launch 'd2j-dex2jar.sh' '-h' 'bash -l'"
 Icon=mobile
 Type=Application
+Terminal=true

--- a/src/share/genmenu/desktop/dex2jar.desktop
+++ b/src/share/genmenu/desktop/dex2jar.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=Dex2jar
+Exec=/bin/sh -c "/usr/bin/launch 'd2j-dex2jar.sh' '-h' 'bash -l'"
+Icon=mobile
+Type=Application

--- a/src/share/genmenu/desktop/inception.desktop
+++ b/src/share/genmenu/desktop/inception.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=Inception
+Exec=/bin/sh -c "/usr/bin/launch 'incept' '-h' 'bash -l'"
+Icon=forensics
+Type=Application

--- a/src/share/genmenu/desktop/inception.desktop
+++ b/src/share/genmenu/desktop/inception.desktop
@@ -1,5 +1,8 @@
 [Desktop Entry]
 Name=Inception
+GenericName=
 Exec=/bin/sh -c "/usr/bin/launch 'incept' '-h' 'bash -l'"
 Icon=forensics
 Type=Application
+Terminal=true
+Categories=Pentoo

--- a/src/share/genmenu/desktop/svcrack.desktop
+++ b/src/share/genmenu/desktop/svcrack.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=Svcrack
+Exec=/bin/sh -c "/usr/bin/launch 'sipvicious_svcrack' '-h' 'bash -l'"
+Icon=sip-voip
+Type=Application

--- a/src/share/genmenu/desktop/svcrack.desktop
+++ b/src/share/genmenu/desktop/svcrack.desktop
@@ -3,3 +3,4 @@ Name=Svcrack
 Exec=/bin/sh -c "/usr/bin/launch 'sipvicious_svcrack' '-h' 'bash -l'"
 Icon=sip-voip
 Type=Application
+Terminal=true

--- a/src/share/genmenu/desktop/svmap.desktop
+++ b/src/share/genmenu/desktop/svmap.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=Svmap
+Exec=/bin/sh -c "/usr/bin/launch 'sipvicious_svmap' '-h' 'bash -l'"
+Icon=sip-voip
+Type=Application

--- a/src/share/genmenu/desktop/svmap.desktop
+++ b/src/share/genmenu/desktop/svmap.desktop
@@ -3,3 +3,4 @@ Name=Svmap
 Exec=/bin/sh -c "/usr/bin/launch 'sipvicious_svmap' '-h' 'bash -l'"
 Icon=sip-voip
 Type=Application
+Terminal=true

--- a/src/share/genmenu/desktop/svreport.desktop
+++ b/src/share/genmenu/desktop/svreport.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=Svreport
+Exec=/bin/sh -c "/usr/bin/launch 'sipvicious_svreport' '-h' 'bash -l'"
+Icon=sip-voip
+Type=Application

--- a/src/share/genmenu/desktop/svreport.desktop
+++ b/src/share/genmenu/desktop/svreport.desktop
@@ -3,3 +3,4 @@ Name=Svreport
 Exec=/bin/sh -c "/usr/bin/launch 'sipvicious_svreport' '-h' 'bash -l'"
 Icon=sip-voip
 Type=Application
+Terminal=true

--- a/src/share/genmenu/desktop/svwar.desktop
+++ b/src/share/genmenu/desktop/svwar.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=Svwar
+Exec=/bin/sh -c "/usr/bin/launch 'sipvicious_svwar' '-h' 'bash -l'"
+Icon=sip-voip
+Type=Application

--- a/src/share/genmenu/desktop/svwar.desktop
+++ b/src/share/genmenu/desktop/svwar.desktop
@@ -3,3 +3,4 @@ Name=Svwar
 Exec=/bin/sh -c "/usr/bin/launch 'sipvicious_svwar' '-h' 'bash -l'"
 Icon=sip-voip
 Type=Application
+Terminal=true

--- a/src/share/genmenu/desktop/traceroute.desktop
+++ b/src/share/genmenu/desktop/traceroute.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=Inception
+Exec=/bin/sh -c "/usr/bin/launch 'incept' '-h' 'bash -l'"
+Icon=forensics
+Type=Application

--- a/src/share/genmenu/desktop/yersinia-cmd.desktop
+++ b/src/share/genmenu/desktop/yersinia-cmd.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Yersinia
 GenericName=cli
-Exec=P2TERM -e launch yersinia -h
+Exec=/bin/sh -c "/usr/bin/launch '/usr/bin/yersinia' '-h' 'bash -l'"
 StartupNotify=false
 X-Enlightenment-WaitExit=false
 Icon=exploit

--- a/src/share/genmenu/desktop/yersinia-cmd.desktop
+++ b/src/share/genmenu/desktop/yersinia-cmd.desktop
@@ -6,3 +6,4 @@ StartupNotify=false
 X-Enlightenment-WaitExit=false
 Icon=exploit
 Type=Application
+Terminal=true


### PR DESCRIPTION
This pull request includes explicit config fixes for:

- svcrack
- svmap
- svreport
- svwar
- inception
- yersinia-cmd
- and dex2jar

such that they properly display help text when clicked. Additionally, database entries for libbtbb and clang have been removed; one is a shared library and the other is a compiler misplaced into `Pentoo -> Mobile`.