### PR TITLE
Fix traceroute menu option

### DIFF
--- a/src/share/genmenu/db.csv
+++ b/src/share/genmenu/db.csv
@@ -165,7 +165,7 @@ net-analyzer/thc-ipv6,analyzer thc-ipv6, address6 alive6 covert_send6 covert_sen
 net-analyzer/thc-pptp-bruter,cracker,thc-pptp-bruter
 net-analyzer/thcrut,analyzer,thcrut
 net-analyzer/theHarvester,footprint Mail,theHarvester.py
-net-analyzer/traceroute,analyzer,traceroute
+net-analyzer/traceroute,analyzer,traceroute.desktop
 net-analyzer/ucsniff,sip-voip,ucsniff
 net-analyzer/upnpscan,scanner,upnpscan
 net-analyzer/upnpwn,exploit,upnpwn

--- a/src/share/genmenu/desktop/traceroute.desktop
+++ b/src/share/genmenu/desktop/traceroute.desktop
@@ -1,5 +1,6 @@
 [Desktop Entry]
-Name=Inception
-Exec=/bin/sh -c "/usr/bin/launch 'incept' '-h' 'bash -l'"
-Icon=forensics
+Name=Traceroute
+Exec=/bin/sh -c "/usr/bin/launch 'traceroute' '--help' 'bash -l'"
+Icon=analyzer
 Type=Application
+Terminal=true


### PR DESCRIPTION
This change modifies the traceroute menu option to properly display help text when selected, rather than quitting without displaying anything.